### PR TITLE
Add content_length fibbing scripts

### DIFF
--- a/content_length_exaggeration.sh
+++ b/content_length_exaggeration.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+SOCAT=$(which socat 2>/dev/null)
+[ -z "$SOCAT" ] && (echo "socat not found. Try installing the socat package."; exit 2)
+set -e
+
+echo -ne "HTTP/1.1 20O OK\r
+Content-Type: text/plain\r
+Content-Length: 1296\r
+Connection: close\r
+\r
+It is with humility really unassumed — it is with a sentiment even of awe — that I pen the opening sentence of this work: for of all conceivable subjects I approach the reader with the most solemn — the most comprehensive — the most difficult — the most august.
+
+What terms shall I find sufficiently simple in their sublimity — sufficiently sublime in their simplicity — for the mere enunciation of my theme?
+
+I design to speak of the Physical, Metaphysical and Mathematical — of the Material and Spiritual Universe: — of its Essence, its Origin, its Creation, its Present Condition and its Destiny. I shall be so rash, moreover, as to challenge the conclusions, and thus, in effect, to question the sagacity, of many of the greatest and most justly reverenced of men. [page 8:]
+
+In the beginning, let me as distinctly as possible announce — not the theorem which I hope to demonstrate — for, whatever the mathematicians may assert, there is, in this world at least, no such thing as demonstration — but the ruling idea which, throughout this volume, I shall be continually endeavoring to suggest.
+
+My general proposition, then, is this: — In the Original Unity of the First Thing lies the Secondary Cause of All Things, with the Germ of their " | socat -t1800 -T1800 TCP-L:8080,reuseaddr,shut-none STDIO

--- a/content_length_megalomania.sh
+++ b/content_length_megalomania.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+SOCAT=$(which socat 2>/dev/null)
+[ -z "$SOCAT" ] && (echo "socat not found. Try installing the socat package."; exit 2)
+set -e
+
+echo -ne "HTTP/1.1 20O OK\r
+Content-Type: text/plain\r
+Content-Length: 1424967069597696\r
+Connection: close\r
+\r
+It is with humility really unassumed — it is with a sentiment even of awe — that I pen the opening sentence of this work: for of all conceivable subjects I approach the reader with the most solemn — the most comprehensive — the most difficult — the most august.
+
+What terms shall I find sufficiently simple in their sublimity — sufficiently sublime in their simplicity — for the mere enunciation of my theme?
+
+I design to speak of the Physical, Metaphysical and Mathematical — of the Material and Spiritual Universe: — of its Essence, its Origin, its Creation, its Present Condition and its Destiny. I shall be so rash, moreover, as to challenge the conclusions, and thus, in effect, to question the sagacity, of many of the greatest and most justly reverenced of men. [page 8:]
+
+In the beginning, let me as distinctly as possible announce — not the theorem which I hope to demonstrate — for, whatever the mathematicians may assert, there is, in this world at least, no such thing as demonstration — but the ruling idea which, throughout this volume, I shall be continually endeavoring to suggest.
+
+My general proposition, then, is this: — In the Original Unity of the First Thing lies the Secondary Cause of All Things, with the Germ of their " | socat -t1800 -T1800 TCP-L:8080,reuseaddr,shut-none STDIO

--- a/content_length_understatement.sh
+++ b/content_length_understatement.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+SOCAT=$(which socat 2>/dev/null)
+[ -z "$SOCAT" ] && (echo "socat not found. Try installing the socat package."; exit 2)
+set -e
+
+echo -ne "HTTP/1.1 20O OK\r
+Content-Type: text/plain\r
+Content-Length: 1024\r
+Connection: close\r
+\r
+It is with humility really unassumed — it is with a sentiment even of awe — that I pen the opening sentence of this work: for of all conceivable subjects I approach the reader with the most solemn — the most comprehensive — the most difficult — the most august.
+
+What terms shall I find sufficiently simple in their sublimity — sufficiently sublime in their simplicity — for the mere enunciation of my theme?
+
+I design to speak of the Physical, Metaphysical and Mathematical — of the Material and Spiritual Universe: — of its Essence, its Origin, its Creation, its Present Condition and its Destiny. I shall be so rash, moreover, as to challenge the conclusions, and thus, in effect, to question the sagacity, of many of the greatest and most justly reverenced of men. [page 8:]
+
+In the beginning, let me as distinctly as possible announce — not the theorem which I hope to demonstrate — for, whatever the mathematicians may assert, there is, in this world at least, no such thing as demonstration — but the ruling idea which, throughout this volume, I shall be continually endeavoring to suggest.
+
+My general proposition, then, is this: — In the Original Unity of the First Thing lies the Secondary Cause of All Things, with the Germ of their " | socat -t1800 -T1800 TCP-L:8080,reuseaddr,shut-none STDIO


### PR DESCRIPTION
Three scripts are added which test against known problems for simple HTTP clients when handling the `Content-Length` header:

1. **Understatement**: The content is longer than the content length. This is mostly an internal fault test.
2. **Exaggeration**: The content is shorter than the content length. This is is really a timeout handling test.
3. **Megalomania**: The content length is an extremely large value, which:
    a. overflows a 32-bit integer (many times)
    b. results in a value of zero if truncated to a 32-bit integer
    c. exceeds available memory on every box ever built
    This tests for silly developer shortcuts, [some famous](https://bugs.php.net/bug.php?id=61461), others observed in my past.

All three scripts are designed to be similar in spirit to those that came before, but have a couple caveats:
* They require `socat` instead of netcat. Since that is not commonly installed, I check for it.
* They cannot simulate an infinite timeout, so I picked 30 minutes. That should be enough for a user to realize, "hey, why is my client hanging like this?"