### PR TITLE
Add Content-Encoding and Transfer-Encoding scripts

### DIFF
--- a/content_enc_brotli.sh
+++ b/content_enc_brotli.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+SOCAT=$(which socat 2>/dev/null)
+[ -z "$SOCAT" ] && (echo "socat not found. Try installing the socat package."; exit 2)
+set -e
+
+echo -ne "HTTP/1.1 20O OK\r
+Content-Type: text/plain\r
+Content-Length: 1122\r
+Connection: close\r
+Content-Encoding: br
+\r
+It is with humility really unassumed — it is with a sentiment even of awe — that I pen the opening sentence of this work: for of all conceivable subjects I approach the reader with the most solemn — the most comprehensive — the most difficult — the most august.
+
+What terms shall I find sufficiently simple in their sublimity — sufficiently sublime in their simplicity — for the mere enunciation of my theme?
+
+I design to speak of the Physical, Metaphysical and Mathematical — of the Material and Spiritual Universe: — of its Essence, its Origin, its Creation, its Present Condition and its Destiny. I shall be so rash, moreover, as to challenge the conclusions, and thus, in effect, to question the sagacity, of many of the greatest and most justly reverenced of men. [page 8:]
+
+In the beginning, let me as distinctly as possible announce — not the theorem which I hope to demonstrate — for, whatever the mathematicians may assert, there is, in this world at least, no such thing as demonstration — but the ruling idea which, throughout this volume, I shall be continually endeavoring to suggest.
+" | socat -t1800 -T1800 TCP-L:8080,reuseaddr,shut-none STDIO

--- a/content_enc_deflate_mismatch.sh
+++ b/content_enc_deflate_mismatch.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+SOCAT=$(which socat 2>/dev/null)
+[ -z "$SOCAT" ] && (echo "socat not found. Try installing the socat package."; exit 2)
+set -e
+
+echo -ne "HTTP/1.1 20O OK\r
+Content-Type: text/plain\r
+Content-Length: 1122\r
+Connection: close\r
+Content-Encoding: deflate
+\r
+It is with humility really unassumed — it is with a sentiment even of awe — that I pen the opening sentence of this work: for of all conceivable subjects I approach the reader with the most solemn — the most comprehensive — the most difficult — the most august.
+
+What terms shall I find sufficiently simple in their sublimity — sufficiently sublime in their simplicity — for the mere enunciation of my theme?
+
+I design to speak of the Physical, Metaphysical and Mathematical — of the Material and Spiritual Universe: — of its Essence, its Origin, its Creation, its Present Condition and its Destiny. I shall be so rash, moreover, as to challenge the conclusions, and thus, in effect, to question the sagacity, of many of the greatest and most justly reverenced of men. [page 8:]
+
+In the beginning, let me as distinctly as possible announce — not the theorem which I hope to demonstrate — for, whatever the mathematicians may assert, there is, in this world at least, no such thing as demonstration — but the ruling idea which, throughout this volume, I shall be continually endeavoring to suggest.
+" | socat -t1800 -T1800 TCP-L:8080,reuseaddr,shut-none STDIO

--- a/content_enc_gzip_mismatch.sh
+++ b/content_enc_gzip_mismatch.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+SOCAT=$(which socat 2>/dev/null)
+[ -z "$SOCAT" ] && (echo "socat not found. Try installing the socat package."; exit 2)
+set -e
+
+echo -ne "HTTP/1.1 20O OK\r
+Content-Type: text/plain\r
+Content-Length: 1122\r
+Connection: close\r
+Content-Encoding: gzip
+\r
+It is with humility really unassumed — it is with a sentiment even of awe — that I pen the opening sentence of this work: for of all conceivable subjects I approach the reader with the most solemn — the most comprehensive — the most difficult — the most august.
+
+What terms shall I find sufficiently simple in their sublimity — sufficiently sublime in their simplicity — for the mere enunciation of my theme?
+
+I design to speak of the Physical, Metaphysical and Mathematical — of the Material and Spiritual Universe: — of its Essence, its Origin, its Creation, its Present Condition and its Destiny. I shall be so rash, moreover, as to challenge the conclusions, and thus, in effect, to question the sagacity, of many of the greatest and most justly reverenced of men. [page 8:]
+
+In the beginning, let me as distinctly as possible announce — not the theorem which I hope to demonstrate — for, whatever the mathematicians may assert, there is, in this world at least, no such thing as demonstration — but the ruling idea which, throughout this volume, I shall be continually endeavoring to suggest.
+" | socat -t1800 -T1800 TCP-L:8080,reuseaddr,shut-none STDIO

--- a/content_enc_klingon.sh
+++ b/content_enc_klingon.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+SOCAT=$(which socat 2>/dev/null)
+[ -z "$SOCAT" ] && (echo "socat not found. Try installing the socat package."; exit 2)
+set -e
+
+echo -ne "HTTP/1.1 20O OK\r
+Content-Type: text/plain\r
+Content-Length: 466\r
+Connection: close\r
+Content-Encoding: klingon
+\r
+— — jatlhbe'taHbogh ghu'vam, vaj ngeDqu'bogh law', tangq — — —a' targhmey'e' vISov.
+
+— — ghu'vammo' qatlh mInDu' vISovbogh nuq?
+
+'ej vaj vIpoSmoHchu' jIHvaD neH tIpwIj, — — 'eSpInSa' ghe''or je, qonta'bogh qamDu'Daj je. qaStaHvIS poHmey, mudevtaHvIS, qar'a'?
+
+— — — 'ach yuQmey vIghajbe', 'ach qechmey'e' vI'ang jIvumtaH 'e' vInIDmeH, 'ej jIvumtaHvIS, pagh, jIvumtaHvIS 'e' vIchIDmeH, pagh vIvumlu'chu'mo' 'e' vInIDmeH, pagh vImuSHa'chu'mo'.
+" | socat -t1800 -T1800 TCP-L:8080,reuseaddr,shut-none STDIO

--- a/content_enc_lzw.sh
+++ b/content_enc_lzw.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+SOCAT=$(which socat 2>/dev/null)
+[ -z "$SOCAT" ] && (echo "socat not found. Try installing the socat package."; exit 2)
+set -e
+
+echo -ne "HTTP/1.1 20O OK\r
+Content-Type: text/plain\r
+Content-Length: 1122\r
+Connection: close\r
+Content-Encoding: compress
+\r
+It is with humility really unassumed — it is with a sentiment even of awe — that I pen the opening sentence of this work: for of all conceivable subjects I approach the reader with the most solemn — the most comprehensive — the most difficult — the most august.
+
+What terms shall I find sufficiently simple in their sublimity — sufficiently sublime in their simplicity — for the mere enunciation of my theme?
+
+I design to speak of the Physical, Metaphysical and Mathematical — of the Material and Spiritual Universe: — of its Essence, its Origin, its Creation, its Present Condition and its Destiny. I shall be so rash, moreover, as to challenge the conclusions, and thus, in effect, to question the sagacity, of many of the greatest and most justly reverenced of men. [page 8:]
+
+In the beginning, let me as distinctly as possible announce — not the theorem which I hope to demonstrate — for, whatever the mathematicians may assert, there is, in this world at least, no such thing as demonstration — but the ruling idea which, throughout this volume, I shall be continually endeavoring to suggest.
+" | socat -t1800 -T1800 TCP-L:8080,reuseaddr,shut-none STDIO

--- a/content_enc_zstd_mismatch.sh
+++ b/content_enc_zstd_mismatch.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+SOCAT=$(which socat 2>/dev/null)
+[ -z "$SOCAT" ] && (echo "socat not found. Try installing the socat package."; exit 2)
+set -e
+
+echo -ne "HTTP/1.1 20O OK\r
+Content-Type: text/plain\r
+Content-Length: 1122\r
+Connection: close\r
+Content-Encoding: zstd
+\r
+It is with humility really unassumed — it is with a sentiment even of awe — that I pen the opening sentence of this work: for of all conceivable subjects I approach the reader with the most solemn — the most comprehensive — the most difficult — the most august.
+
+What terms shall I find sufficiently simple in their sublimity — sufficiently sublime in their simplicity — for the mere enunciation of my theme?
+
+I design to speak of the Physical, Metaphysical and Mathematical — of the Material and Spiritual Universe: — of its Essence, its Origin, its Creation, its Present Condition and its Destiny. I shall be so rash, moreover, as to challenge the conclusions, and thus, in effect, to question the sagacity, of many of the greatest and most justly reverenced of men. [page 8:]
+
+In the beginning, let me as distinctly as possible announce — not the theorem which I hope to demonstrate — for, whatever the mathematicians may assert, there is, in this world at least, no such thing as demonstration — but the ruling idea which, throughout this volume, I shall be continually endeavoring to suggest.
+" | socat -t1800 -T1800 TCP-L:8080,reuseaddr,shut-none STDIO

--- a/transfer_brotli_mismatch.sh
+++ b/transfer_brotli_mismatch.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+SOCAT=$(which socat 2>/dev/null)
+[ -z "$SOCAT" ] && (echo "socat not found. Try installing the socat package."; exit 2)
+set -e
+
+echo -ne "HTTP/1.1 20O OK\r
+Content-Type: text/plain\r
+Content-Length: 1122\r
+Connection: close\r
+Transfer-Encoding: br
+\r
+It is with humility really unassumed — it is with a sentiment even of awe — that I pen the opening sentence of this work: for of all conceivable subjects I approach the reader with the most solemn — the most comprehensive — the most difficult — the most august.
+
+What terms shall I find sufficiently simple in their sublimity — sufficiently sublime in their simplicity — for the mere enunciation of my theme?
+
+I design to speak of the Physical, Metaphysical and Mathematical — of the Material and Spiritual Universe: — of its Essence, its Origin, its Creation, its Present Condition and its Destiny. I shall be so rash, moreover, as to challenge the conclusions, and thus, in effect, to question the sagacity, of many of the greatest and most justly reverenced of men. [page 8:]
+
+In the beginning, let me as distinctly as possible announce — not the theorem which I hope to demonstrate — for, whatever the mathematicians may assert, there is, in this world at least, no such thing as demonstration — but the ruling idea which, throughout this volume, I shall be continually endeavoring to suggest.
+" | socat -t1800 -T1800 TCP-L:8080,reuseaddr,shut-none STDIO

--- a/transfer_deflate_mismatch.sh
+++ b/transfer_deflate_mismatch.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+SOCAT=$(which socat 2>/dev/null)
+[ -z "$SOCAT" ] && (echo "socat not found. Try installing the socat package."; exit 2)
+set -e
+
+echo -ne "HTTP/1.1 20O OK\r
+Content-Type: text/plain\r
+Content-Length: 1122\r
+Connection: close\r
+Transfer-Encoding: deflate
+\r
+It is with humility really unassumed — it is with a sentiment even of awe — that I pen the opening sentence of this work: for of all conceivable subjects I approach the reader with the most solemn — the most comprehensive — the most difficult — the most august.
+
+What terms shall I find sufficiently simple in their sublimity — sufficiently sublime in their simplicity — for the mere enunciation of my theme?
+
+I design to speak of the Physical, Metaphysical and Mathematical — of the Material and Spiritual Universe: — of its Essence, its Origin, its Creation, its Present Condition and its Destiny. I shall be so rash, moreover, as to challenge the conclusions, and thus, in effect, to question the sagacity, of many of the greatest and most justly reverenced of men. [page 8:]
+
+In the beginning, let me as distinctly as possible announce — not the theorem which I hope to demonstrate — for, whatever the mathematicians may assert, there is, in this world at least, no such thing as demonstration — but the ruling idea which, throughout this volume, I shall be continually endeavoring to suggest.
+" | socat -t1800 -T1800 TCP-L:8080,reuseaddr,shut-none STDIO

--- a/transfer_gzip_mismatch.sh
+++ b/transfer_gzip_mismatch.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+SOCAT=$(which socat 2>/dev/null)
+[ -z "$SOCAT" ] && (echo "socat not found. Try installing the socat package."; exit 2)
+set -e
+
+echo -ne "HTTP/1.1 20O OK\r
+Content-Type: text/plain\r
+Content-Length: 1122\r
+Connection: close\r
+Transfer-Encoding: gzip
+\r
+It is with humility really unassumed — it is with a sentiment even of awe — that I pen the opening sentence of this work: for of all conceivable subjects I approach the reader with the most solemn — the most comprehensive — the most difficult — the most august.
+
+What terms shall I find sufficiently simple in their sublimity — sufficiently sublime in their simplicity — for the mere enunciation of my theme?
+
+I design to speak of the Physical, Metaphysical and Mathematical — of the Material and Spiritual Universe: — of its Essence, its Origin, its Creation, its Present Condition and its Destiny. I shall be so rash, moreover, as to challenge the conclusions, and thus, in effect, to question the sagacity, of many of the greatest and most justly reverenced of men. [page 8:]
+
+In the beginning, let me as distinctly as possible announce — not the theorem which I hope to demonstrate — for, whatever the mathematicians may assert, there is, in this world at least, no such thing as demonstration — but the ruling idea which, throughout this volume, I shall be continually endeavoring to suggest.
+" | socat -t1800 -T1800 TCP-L:8080,reuseaddr,shut-none STDIO

--- a/transfer_identity.sh
+++ b/transfer_identity.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+SOCAT=$(which socat 2>/dev/null)
+[ -z "$SOCAT" ] && (echo "socat not found. Try installing the socat package."; exit 2)
+set -e
+
+echo -ne "HTTP/1.1 20O OK\r
+Content-Type: text/plain\r
+Content-Length: 1122\r
+Connection: close\r
+Transfer-Encoding: identity
+\r
+It is with humility really unassumed — it is with a sentiment even of awe — that I pen the opening sentence of this work: for of all conceivable subjects I approach the reader with the most solemn — the most comprehensive — the most difficult — the most august.
+
+What terms shall I find sufficiently simple in their sublimity — sufficiently sublime in their simplicity — for the mere enunciation of my theme?
+
+I design to speak of the Physical, Metaphysical and Mathematical — of the Material and Spiritual Universe: — of its Essence, its Origin, its Creation, its Present Condition and its Destiny. I shall be so rash, moreover, as to challenge the conclusions, and thus, in effect, to question the sagacity, of many of the greatest and most justly reverenced of men. [page 8:]
+
+In the beginning, let me as distinctly as possible announce — not the theorem which I hope to demonstrate — for, whatever the mathematicians may assert, there is, in this world at least, no such thing as demonstration — but the ruling idea which, throughout this volume, I shall be continually endeavoring to suggest.
+" | socat -t1800 -T1800 TCP-L:8080,reuseaddr,shut-none STDIO

--- a/transfer_klingon.sh
+++ b/transfer_klingon.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+SOCAT=$(which socat 2>/dev/null)
+[ -z "$SOCAT" ] && (echo "socat not found. Try installing the socat package."; exit 2)
+set -e
+
+echo -ne "HTTP/1.1 20O OK\r
+Content-Type: text/plain\r
+Content-Length: 466\r
+Connection: close\r
+Transfer-Encoding: klingon
+\r
+— — jatlhbe'taHbogh ghu'vam, vaj ngeDqu'bogh law', tangq — — —a' targhmey'e' vISov.
+
+— — ghu'vammo' qatlh mInDu' vISovbogh nuq?
+
+'ej vaj vIpoSmoHchu' jIHvaD neH tIpwIj, — — 'eSpInSa' ghe''or je, qonta'bogh qamDu'Daj je. qaStaHvIS poHmey, mudevtaHvIS, qar'a'?
+
+— — — 'ach yuQmey vIghajbe', 'ach qechmey'e' vI'ang jIvumtaH 'e' vInIDmeH, 'ej jIvumtaHvIS, pagh, jIvumtaHvIS 'e' vIchIDmeH, pagh vIvumlu'chu'mo' 'e' vInIDmeH, pagh vImuSHa'chu'mo'.
+" | socat -t1800 -T1800 TCP-L:8080,reuseaddr,shut-none STDIO

--- a/transfer_lzw_mismatch.sh
+++ b/transfer_lzw_mismatch.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+SOCAT=$(which socat 2>/dev/null)
+[ -z "$SOCAT" ] && (echo "socat not found. Try installing the socat package."; exit 2)
+set -e
+
+echo -ne "HTTP/1.1 20O OK\r
+Content-Type: text/plain\r
+Content-Length: 1122\r
+Connection: close\r
+Transfer-Encoding: compress
+\r
+It is with humility really unassumed — it is with a sentiment even of awe — that I pen the opening sentence of this work: for of all conceivable subjects I approach the reader with the most solemn — the most comprehensive — the most difficult — the most august.
+
+What terms shall I find sufficiently simple in their sublimity — sufficiently sublime in their simplicity — for the mere enunciation of my theme?
+
+I design to speak of the Physical, Metaphysical and Mathematical — of the Material and Spiritual Universe: — of its Essence, its Origin, its Creation, its Present Condition and its Destiny. I shall be so rash, moreover, as to challenge the conclusions, and thus, in effect, to question the sagacity, of many of the greatest and most justly reverenced of men. [page 8:]
+
+In the beginning, let me as distinctly as possible announce — not the theorem which I hope to demonstrate — for, whatever the mathematicians may assert, there is, in this world at least, no such thing as demonstration — but the ruling idea which, throughout this volume, I shall be continually endeavoring to suggest.
+" | socat -t1800 -T1800 TCP-L:8080,reuseaddr,shut-none STDIO

--- a/transfer_zstd_mismatch.sh
+++ b/transfer_zstd_mismatch.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+SOCAT=$(which socat 2>/dev/null)
+[ -z "$SOCAT" ] && (echo "socat not found. Try installing the socat package."; exit 2)
+set -e
+
+echo -ne "HTTP/1.1 20O OK\r
+Content-Type: text/plain\r
+Content-Length: 1122\r
+Connection: close\r
+Transfer-Encoding: zstd
+\r
+It is with humility really unassumed — it is with a sentiment even of awe — that I pen the opening sentence of this work: for of all conceivable subjects I approach the reader with the most solemn — the most comprehensive — the most difficult — the most august.
+
+What terms shall I find sufficiently simple in their sublimity — sufficiently sublime in their simplicity — for the mere enunciation of my theme?
+
+I design to speak of the Physical, Metaphysical and Mathematical — of the Material and Spiritual Universe: — of its Essence, its Origin, its Creation, its Present Condition and its Destiny. I shall be so rash, moreover, as to challenge the conclusions, and thus, in effect, to question the sagacity, of many of the greatest and most justly reverenced of men. [page 8:]
+
+In the beginning, let me as distinctly as possible announce — not the theorem which I hope to demonstrate — for, whatever the mathematicians may assert, there is, in this world at least, no such thing as demonstration — but the ruling idea which, throughout this volume, I shall be continually endeavoring to suggest.
+" | socat -t1800 -T1800 TCP-L:8080,reuseaddr,shut-none STDIO


### PR DESCRIPTION
This adds scripts to test `Content-Encoding` and `Transfer-Enconding` headers with improper or weird values. The tests for each type are:

1. Claim the content is compressed (deflate, gzip, and zstd) but isn't.
1. Claim an encoding that is entirely made up.
1. For the `Transfer-Encoding` header, specify the RFC value `identity`. (This is mostly a sanity check.)

While I hope these headers are unprocessed by clients, [even a small mistake can break other software](https://nvd.nist.gov/vuln/detail/CVE-2019-17569).